### PR TITLE
fix selection issue

### DIFF
--- a/FrienDex/Views/RoomsPage.xaml
+++ b/FrienDex/Views/RoomsPage.xaml
@@ -7,16 +7,19 @@
 
     <Grid RowDefinitions="*,Auto" Padding="16">
 
-        <!-- Rooms List -->
         <CollectionView
             ItemsSource="{Binding Rooms}"
-            SelectionMode="Single"
-            SelectionChangedCommand="{Binding RoomSelectedCommand}"
-            SelectionChangedCommandParameter="{Binding SelectedItem, Source={RelativeSource Self}}">
+            SelectionMode="None">
 
             <CollectionView.ItemTemplate>
                 <DataTemplate>
                     <Grid Padding="12" RowDefinitions="Auto,Auto">
+                        <Grid.GestureRecognizers>
+                            <TapGestureRecognizer 
+                                Command="{Binding Source={RelativeSource AncestorType={x:Type ContentPage}}, BindingContext.RoomSelectedCommand}"
+                                CommandParameter="{Binding .}" />
+                        </Grid.GestureRecognizers>
+
                         <Label 
                             Text="{Binding Name}" 
                             FontSize="18" 
@@ -33,7 +36,6 @@
 
         </CollectionView>
 
-        <!-- Add Room Button -->
         <Button
             Grid.Row="1"
             Text="Add Room"

--- a/FrienDex/Views/RoomsPage.xaml.cs
+++ b/FrienDex/Views/RoomsPage.xaml.cs
@@ -5,6 +5,7 @@ using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Windows.Input;
 using FrienDex.Views;
+using System.Diagnostics;
 
 namespace FrienDex;
 
@@ -14,6 +15,17 @@ public partial class RoomsPage : ContentPage
     {
         InitializeComponent();
         BindingContext = new RoomsPageViewModel(this, roomRepo);
+    }
+
+    protected override async void OnAppearing()
+    {
+        base.OnAppearing();
+
+        // This ensures the state is reset/refreshed every time you navigate back
+        if (BindingContext is RoomsPageViewModel viewModel)
+        {
+            await viewModel.RefreshRooms();
+        }
     }
 }
 
@@ -45,11 +57,10 @@ public class RoomsPageViewModel : INotifyPropertyChanged
             if (selectedRoom != value)
             {
                 selectedRoom = value;
-                OnPropertyChanged();
             }
+            OnPropertyChanged();
         }
     }
-
 
     public ICommand AddRoomCommand { get; }
     public ICommand RoomSelectedCommand { get; }
@@ -58,23 +69,30 @@ public class RoomsPageViewModel : INotifyPropertyChanged
     {
         _page = page;
         _roomRepo = roomRepo;
-        Rooms = new ObservableCollection<Room>();
-        AddRoomCommand = new Command(OnAddRoom);
-        RoomSelectedCommand = new Command<Room>(OnRoomSelected);
 
-        LoadRooms();
+        Rooms = new ObservableCollection<Room>();
+
+        AddRoomCommand = new Command(OnAddRoom);
+        // Parameter is now passed directly from the TapGestureRecognizer
+        RoomSelectedCommand = new Command<Room>(OnRoomSelected);
     }
-    
+
     /// <summary>
-    /// Fetches the list of rooms from the data source and populates the Rooms collection.
+    /// Clears the current state and reloads rooms from the repository.
+    /// Call this from OnAppearing in the code-behind.
     /// </summary>
-    private async void LoadRooms()
+    public async Task RefreshRooms()
     {
         var roomsFromRepo = await _roomRepo.ReadAllAsync();
+
+        Rooms.Clear();
         foreach (var room in roomsFromRepo)
         {
             Rooms.Add(room);
         }
+
+        // Reset the selection property to null to ensure a clean state
+        SelectedRoom = null;
     }
 
     private async void OnAddRoom()
@@ -85,7 +103,12 @@ public class RoomsPageViewModel : INotifyPropertyChanged
         var newRoom = await addPage.ResultTcs.Task;
         if (newRoom != null)
         {
-            Rooms.Add(newRoom);
+            // The room will also be caught by RefreshRooms when OnAppearing fires,
+            // but adding it here provides immediate UI feedback.
+            if (!Rooms.Any(r => r.Id == newRoom.Id))
+            {
+                Rooms.Add(newRoom);
+            }
         }
     }
 
@@ -93,12 +116,13 @@ public class RoomsPageViewModel : INotifyPropertyChanged
     {
         if (room == null) return;
 
+        Debug.WriteLine($"Navigating to room: {room.Name}");
+
+        // Navigation fires every time because we use TapGesture + SelectionMode="None"
         await Shell.Current.GoToAsync($"{nameof(ViewRoomPage)}?RoomId={room.Id}");
     }
 
-
     public event PropertyChangedEventHandler? PropertyChanged;
-
     protected void OnPropertyChanged([CallerMemberName] string propertyName = "")
     {
         PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));


### PR DESCRIPTION
## Description of changes made:
#### *Please describe the changes you made. Be descriptive. This is for us to look back on to see progress made.*
Fix issue #34 so that users can go to the same room the just navigated back from without selecting the other room first.

## Changelog:
#### *Please use bullet point notation (e.g. `- example`) and list changes in end user friendly language.*
- Changed from CollectionView binding with OnSelectionChanged to TapGestureRecognizer
- Add OnAppearing method to code-behind for RoomsPage to refresh the state of the page when navigated back

## Issue ticket number and link
Issue #34 